### PR TITLE
chore: Bump `target-version` of black tool to `py39`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 125
-target-version = ['py38']
+target-version = ['py39']
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]


### PR DESCRIPTION
Python >=3.9 is already set as the minimum requirement for this project