### PR TITLE
Duplicated requires-python setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inflate64"
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.14"
 description = "deflate64 compression/decompression library"
 readme = "README.rst"
 license = {text = "LGPL-2.1-or-later"}

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,4 @@ setup(
     package_dir={"": "src"},
     packages=packages,
     cmdclass={"build_ext": build_ext_compiler_check, "egg_info": my_egg_info},
-    python_requires=">=3.9, <3.14",
 )


### PR DESCRIPTION
`requires-python` is currently set in two different places:
https://github.com/miurahr/inflate64/blob/86302cb4338856252aa2e6a1d6c7fe3b0f879c6b/pyproject.toml#L3
https://github.com/miurahr/inflate64/blob/86302cb4338856252aa2e6a1d6c7fe3b0f879c6b/setup.py#L69

This change moves the `setup.py` (most recently changed in https://github.com/miurahr/inflate64/pull/2 ) value to `pyproject.toml` and removes the setting from `setup.py`.