### PR TITLE
Drop requires-python upper limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inflate64"
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.14"
 description = "deflate64 compression/decompression library"
 readme = "README.rst"
 license = {text = "LGPL-2.1-or-later"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inflate64"
-requires-python = ">=3.9, <3.14"
+requires-python = ">=3.9"
 description = "deflate64 compression/decompression library"
 readme = "README.rst"
 license = {text = "LGPL-2.1-or-later"}
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",    
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -127,7 +128,7 @@ archs = ["auto64", "universal2"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = check, py{39,310,311,312,313}, docs
+envlist = check, py{39,310,311,312,313,314}, docs
 
 [testenv]
 passenv = PYTEST_ADDOPTS

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,4 @@ setup(
     package_dir={"": "src"},
     packages=packages,
     cmdclass={"build_ext": build_ext_compiler_check, "egg_info": my_egg_info},
-    python_requires=">=3.9, <3.14",
 )


### PR DESCRIPTION
Drop `requires-python` upper limit introduced in https://github.com/miurahr/inflate64/pull/2 and add 3.14 tox axis.

`requires-python` lower bound is already set here https://github.com/miurahr/inflate64/blob/86302cb4338856252aa2e6a1d6c7fe3b0f879c6b/pyproject.toml#L3

This PR also removes the duplicated  `requires-python` setting https://github.com/miurahr/inflate64/blob/86302cb4338856252aa2e6a1d6c7fe3b0f879c6b/setup.py#L69

Introducing a `requires-python` upper bound to a project that previously wasn't using one will not prevent the project from being used on a too recent Python version. Instead of failing, the resolver will pick an older version without the bound, circumventing the bound.