### PR TITLE
CI: Extend Python and OS matrix, update to setup-python v6

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
     env:
+      CIBW_ARCHS_LINUX: "native"
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       # Include latest Python beta
       CIBW_PRERELEASE_PYTHONS: True
@@ -26,17 +27,14 @@ jobs:
       - name: Fetch release tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python 🐍
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Install cibuildwheel
         run: |
           python -m pip install -U pip cibuildwheel
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_ARCHS_LINUX: "native"
-          CIBW_SKIP: "pp*"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -56,7 +54,7 @@ jobs:
       - name: Set up Python 🐍
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.13
       - name: Build source distribution & wheels🎡
         run: |
           python -m pip install -U pip setuptools setuptools_scm[toml] build

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,6 +19,7 @@ jobs:
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       # Include latest Python beta
       CIBW_PRERELEASE_PYTHONS: True
+      CIBW_SKIP: "pp*"
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -25,6 +25,11 @@ jobs:
             python-version: "3.14"
           - os: ubuntu-24.04
             python-version: "pypy-3.10"
+        exclude:
+          - os: ubuntu-24.04-arm
+            python-version: "3.10"
+          - os: windows-11-arm
+            python-version: "3.10"
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -23,11 +23,7 @@ jobs:
         include:
           - os: macos-latest
             python-version: "3.14"
-          - os: ubuntu-24.04
-            python-version: "pypy-3.10"
         exclude:
-          - os: ubuntu-24.04-arm
-            python-version: "3.10"
           - os: windows-11-arm
             python-version: "3.10"
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/run-tox-tests.yml
+++ b/.github/workflows/run-tox-tests.yml
@@ -12,27 +12,28 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-latest]
+        os: [ubuntu-24.04, windows-latest, ubuntu-24.04-arm, windows-11-arm]
         python-version: [
-            "3.9",
             "3.10",
             "3.11",
             "3.12",
             "3.13",
+            "3.14",
         ]
         include:
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.14"
+          - os: ubuntu-24.04
+            python-version: "pypy-3.10"
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 20
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
       - name: Install dependencies
         run: |
           pip install -U pip tox wheel setuptools setuptools_scm[toml]
@@ -40,35 +41,3 @@ jobs:
       - name: Test project with tox
         run: |
           tox
-
-  test_on_aarch64:
-    name: Test on ${{ matrix.arch }}
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        arch: [aarch64]
-        distro: [ubuntu24.04]
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 20
-      - name: Build & run test
-        uses: uraimo/run-on-arch-action@v3
-        with:
-          arch: ${{ matrix.arch }}
-          distro: ${{ matrix.distro }}
-          githubToken: ${{ github.token }}
-          install: |
-            apt-get update -q -y
-            apt-get install -q -y python3-full python3-dev python3-venv build-essential gcc git
-            python3 -m venv /root/venv
-            . /root/venv/bin/activate
-            python3 -m pip install -U pip tox setuptools setuptools_scm[toml]
-          run: |
-            . /root/venv/bin/activate
-            git config --global --add safe.directory ${GITHUB_WORKSPACE}
-            python3 -c "import platform;print('Machine type:', platform.machine())"
-            python3 -m tox -e py312
-          env: |
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Support python3.14 and linux on aarch64, windows 11 on aarch64

ref: https://github.com/miurahr/py7zr/issues/683