### PR TITLE
ci: update build dependencies and simply cibuildwheel configuration

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,7 +20,10 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0 # Required for setuptools_scm
+          persist-credentials: false
       - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
+        with:
+          enable-cache: false
 
       - name: Build SDist
         run: uv build --sdist
@@ -48,8 +51,11 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0 # Required for setuptools_scm
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
+        with:
+          enable-cache: false
 
       - uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc # v3.3.0
 

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -6,84 +6,86 @@ on:
       - releases/*
     tags:
       - v*
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.platform }}
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
-    env:
-      CIBW_ARCHS_LINUX: "native"
-      CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-      # Include latest Python beta
-      CIBW_PRERELEASE_PYTHONS: True
-      CIBW_SKIP: "pp*"
-    steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 20
-      - name: Fetch release tags
-        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - name: Set up Python 🐍
-        uses: actions/setup-python@v6
-        with:
-          python-version: 3.13
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install -U pip cibuildwheel
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-${{ matrix.platform }}
-          path: wheelhouse/*.whl
-
-  build_source_dist:
-    name: Build source dist
+  make-sdist:
+    name: Make SDist
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
-          fetch-depth: 20
-      - name: Fetch release tags
-        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - name: Set up Python 🐍
-        uses: actions/setup-python@v4
+          fetch-depth: 0 # Required for setuptools_scm
+      - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
+
+      - name: Build SDist
+        run: uv build --sdist
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          python-version: 3.13
-      - name: Build source distribution & wheels🎡
-        run: |
-          python -m pip install -U pip setuptools setuptools_scm[toml] build
-          python -m build --sdist
-      - name: Upload source distribution
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifact-source
+          name: cibw-sdist
           path: dist/*.tar.gz
 
-  pypi-publish:
-    name: publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-latest
-    needs: [build_wheels, build_source_dist]
+  build-wheels:
+    name: Wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - windows-latest
+          - windows-11-arm
+          - macos-13
+          - macos-latest
+
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          fetch-depth: 0 # Required for setuptools_scm
+
+      - uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # v7.1.4
+
+      - uses: pypa/cibuildwheel@63fd63b352a9a8bdcc24791c9dbee952ee9a8abc # v3.3.0
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: cibw-wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  publish:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: [make-sdist, build-wheels]
     environment: pypi
     permissions:
       id-token: write
+      attestations: write
+      contents: read
+    runs-on: ubuntu-latest
     steps:
-      - name: download dist artifacts
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
+          pattern: cibw-*
           path: dist
           merge-multiple: true
+
+      - name: Generate artifact attestations
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: "dist/*"
+
       - name: Publish distribution 📦 to Test PyPI
         if: ${{ startsWith(github.event.ref, 'refs/heads/releases') }}
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc  # release/v1.12.4
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1.13.0
         with:
           repository-url: https://test.pypi.org/legacy/
+  
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.event.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1.12.4
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1.13.0

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -14,7 +14,7 @@ clone:
 
 steps:
   check:
-    image: python:${TAG}-bullseye
+    image: python:${TAG}-bookworm
     commands:
       - python -m pip install --upgrade pip
       - python -m pip install tox setuptools setuptools_scm[toml]
@@ -23,8 +23,8 @@ steps:
 
 matrix:
   TAG:
-    - 3.9
     - 3.10
     - 3.11
     - 3.12
     - 3.13
+    - 3.14

--- a/docs/contribution.rst
+++ b/docs/contribution.rst
@@ -112,7 +112,7 @@ CLion is an IDE tool for C/C++ development that support CMake for build configur
 Dependency
 ----------
 
-- Python > 3.9
+- Python > 3.10
 - python development files (for example python3.8-dev package)
 - venv
 - GCC or CLang C/C++ compiler

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "inflate64"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "deflate64 compression/decompression library"
 readme = "README.rst"
-license = {text = "LGPL-2.1-or-later"}
+license = "LGPL-2.1-or-later"
 authors = [
     {name = "Hiroshi Miura", email = "miurahr@linux.com"},
 ]
@@ -16,7 +16,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -51,7 +50,7 @@ check = [
 ]
 
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.0.1"]
+requires = ["setuptools>=80", "setuptools_scm[toml]>=9"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -66,7 +65,7 @@ Changelog = "https://inflate64.readthedocs.io/en/latest/changelog.html"
 
 [tool.black]
 line-length = 125
-target-version = ['py39']
+target-version = ['py310']
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
@@ -106,23 +105,8 @@ python_files = "test*.py"
 norecursedirs = [".git", "_build", "tmp", ".eggs"]
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux_2_28"
-manylinux-aarch64-image = "manylinux_2_28"
-manylinux-ppc64le-image = "manylinux_2_28"
-manylinux-s390x-image = "manylinux_2_28"
-manylinux-pypy_x86_64-image = "manylinux_2_28"
-manylinux-pypy_aarch64-image = "manylinux_2_28"
-
-musllinux-x86_64-image = "musllinux_1_2"
-musllinux-aarch64-image = "musllinux_1_2"
-musllinux-ppc64le-image = "musllinux_1_2"
-musllinux-s390x-image = "musllinux_1_2"
-
-[tool.cibuildwheel.linux]
-archs = ["auto64", "aarch64"]
-
-[tool.cibuildwheel.macos]
-archs = ["auto64", "universal2"]
+archs = "auto64"
+build-frontend = "build[uv]"
 
 [tool.tox]
 legacy_tox_ini = """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ norecursedirs = [".git", "_build", "tmp", ".eggs"]
 
 [tool.cibuildwheel]
 archs = "auto64"
+skip = "cp3??t-*" # Do not build free-threaded wheels (Unsupported)
 build-frontend = "build[uv]"
 
 [tool.tox]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ build-frontend = "build[uv]"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = check, py{39,310,311,312,313,314}, docs
+envlist = check, py{310,311,312,313,314}, docs
 
 [testenv]
 passenv = PYTEST_ADDOPTS


### PR DESCRIPTION
Changes:
- Update build dependencies to get newer features (such as [support for PEP 639 License expressions](https://setuptools.pypa.io/en/stable/history.html#v77-0-0))
- Bump minimum python version from 3.9 to 3.10
- Remove redundant cibuildwheel configuration. For example:
	- cibuildwheel already defaults to `manylinux_2_28` and `musllinux_1_2` so they don't need to be specified anymore. ([ref](https://cibuildwheel.pypa.io/en/stable/options/#linux-image))
	- cibuildwheel no longer automatically builds 32bit wheels so they don't need to be skipped anymore. ([ref](https://cibuildwheel.pypa.io/en/stable/changelog/#v300))
	- cibuildwheel no longer automatically builds pypy wheels so they don't need to be skipped anymore. ([ref](https://cibuildwheel.pypa.io/en/stable/changelog/#v300))
	- Removed macos universal2 wheels because it's redundant considering how we already build x64 and arm wheels. 
- Updated workflow to also build on PRs (but not publish).
- use the `build[uv]` frontend for significantly faster builds in CI.